### PR TITLE
Removed not supported nuget registry

### DIFF
--- a/DigThemGraves/Assets/NuGet.config
+++ b/DigThemGraves/Assets/NuGet.config
@@ -2,7 +2,6 @@
 <configuration>
     <packageSources>
        <add key="NuGet" value="http://www.nuget.org/api/v2/" />
-       <add key="GitHubNuGet" value="https://nuget.pkg.github.com/sweaty-bacon-ducks/" />
     </packageSources>
     <disabledPackageSources />
     <activePackageSource>


### PR DESCRIPTION
Z jakiegoś powodu w konfiguracji Nugeta nie usunąłem wcześniej linka do rejestru githubowego. Ten pr to naprawia.